### PR TITLE
Remove unneeded & uncompleted deploy form

### DIFF
--- a/deploy/templates/sandboxes.html
+++ b/deploy/templates/sandboxes.html
@@ -9,23 +9,6 @@
         </li>
       {% endfor %}
     </ul>
-
-    <h3>Deploy sandbox</h3>
-    <form method="post">
-      <div>
-        Github username:
-        <input type="text" name="username" value="davidread">
-      </div>
-      <div>
-        Email address:
-        <input type="text" name="email" value="david.read@digital.cabinet-office.gov.uk">
-      </div>
-      <div>
-        Full name:
-        <input type="text" name="fullname" value="David Read">
-      </div>
-      <input type="submit" value="Deploy">
-    </form>
   </body>
 
 </html>


### PR DESCRIPTION
This functionality is done in sandbox-mgt. 

Leave the rest of the minimal html interface in sandbox-deploy in case it is helpful.